### PR TITLE
fix: fix trigger release pr workflow call

### DIFF
--- a/.github/workflows/trigger-release-pr.yml
+++ b/.github/workflows/trigger-release-pr.yml
@@ -1,6 +1,6 @@
 name: 'Trigger Release to Production PR'
 on:
-  workflow_dispatch:
+  workflow_call:
     inputs:
       baseBranchName:
         description: 'Production branch name (default: `main`)'


### PR DESCRIPTION
## Description
Fix GH action `trigger-release-pr.yml` error.
https://github.com/Orfium/matching-api/actions/runs/3087939249
update: `workflow_dispatch` -> `workflow_call`

## Checklist

<!-- Please check everything that applies: -->

- [X] I have reviewed my code and checked that there are no unrelated changes in this pull request (old patches, accidental config files, etc)
- [ ] I have created at least one test case for the changes I have made
- [ ] I have updated the documentation (**SwaggerHub**, **README.md**, **Wiki**, etc.) for the changes I have made
