### PR TITLE
fix: fix inputs access on workflow_call of trigger release pr

### DIFF
--- a/.github/workflows/trigger-release-pr.yml
+++ b/.github/workflows/trigger-release-pr.yml
@@ -62,7 +62,7 @@ jobs:
         with:
           github-token: ${{ secrets.token }}
           script: |
-            title = ${{ github.event.inputs.releasePrTitle }};
+            title = ${{ inputs.releasePrTitle }};
             if (title == '') {
               title = 'Release to Production ${{ steps.date.outputs.date }}';
             };
@@ -71,11 +71,11 @@ jobs:
             const result = await github.rest.pulls.create({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              head: ${{ github.event.inputs.headBranchName }},
-              base: ${{ github.event.inputs.baseBranchName }},
+              head: ${{ inputs.headBranchName }},
+              base: ${{ inputs.baseBranchName }},
               title: title,
-              body: ${{ github.event.inputs.releasePrBody }},
-              draft: ${{ github.event.inputs.releasePrIsDraft }}
+              body: ${{ inputs.releasePrBody }},
+              draft: ${{ inputs.releasePrIsDraft }}
             });
             
             // Add labels on automated pr
@@ -83,7 +83,7 @@ jobs:
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: result.data.number,
-              labels: ${{ github.event.inputs.releasePrLabels }}.split(',')
+              labels: ${{ inputs.releasePrLabels }}.split(',')
             });
             
             // Request reviewers on automated pr
@@ -91,6 +91,6 @@ jobs:
               owner: context.repo.owner,
               repo: context.repo.repo,
               pull_number: result.data.number,
-              reviewers: ${{ github.event.inputs.releasePrReviewers }}.split(','),
-              team_reviewers: ${{ github.event.inputs.releasePrTeamReviewers }}.split(',')
+              reviewers: ${{ inputs.releasePrReviewers }}.split(','),
+              team_reviewers: ${{ inputs.releasePrTeamReviewers }}.split(',')
             });

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ jobs:
 On workflows, select the Combine PRs workflow and simply press run.
 
 
-## Trigger release pr to production (periodically)
+## Trigger Release to Production PR (scheduled reusable workflow)
 
 By adding this to your project:
 ```yaml
@@ -64,4 +64,10 @@ jobs:
     secrets:
       token: ${{ secrets.GITHUB_TOKEN }}
 ```
-You can trigger periodically (using cron schedule) the creation of a pr (e.g. main <- develop).
+If the following requirements are met:
+* no PR between `main` and `develop` is open at the time of the workflow run
+* there is diff between the two branches
+
+a `Release to Production` pr will be opened every Tuesdays and Thursdays at 07:25AM UTC, with `develop` as
+head branch and `main` as the base one (main <-- develop), with labels `release` and `automated pr` and with 
+reviewers GitHub users with username `username1` and `username2` and team with slug `teamA`.


### PR DESCRIPTION
## Description

<!-- Write and explain of the changes introduced by this PR for the reviewers to fully understand -->
* Fix inputs access on workflow_call of trigger-release-pr.yml (reusable workflow). Based on Github's official documentation [here](https://docs.github.com/en/actions/using-workflows/reusing-workflows#example-reusable-workflow)
* Update documentation.



## Checklist

<!-- Please check everything that applies: -->

- [X] I have reviewed my code and checked that there are no unrelated changes in this pull request (old patches, accidental config files, etc)
- [ ] I have created at least one test case for the changes I have made
- [X] I have updated the documentation (**SwaggerHub**, **README.md**, **Wiki**, etc.) for the changes I have made
