### PR TITLE
ci: replace deprecating set-output with environment files

### DIFF
--- a/.github/workflows/deploy-frontend.yml
+++ b/.github/workflows/deploy-frontend.yml
@@ -39,8 +39,8 @@ jobs:
           if [[ ${{ github.event_name }} == "pull_request" ]]; then
             ENV=review-${{ github.event.pull_request.number }}
           fi
-          echo "::set-output name=env-name::$ENV"
-          echo "::set-output name=url::https://${SUBDOMAIN}.${BASE_DOMAIN}"
+          echo "env-name=$ENV" >> $GITHUB_OUTPUT
+          echo "url=https://${SUBDOMAIN}.${BASE_DOMAIN}" >> $GITHUB_OUTPUT
 
   deploy-front-end:
     if: ${{ github.actor != 'dependabot[bot]' }}
@@ -77,15 +77,15 @@ jobs:
               STACKNAME=${PRODUCT}-pr-${{ github.event.pull_request.number }}
           fi
 
-          echo "::set-output name=version::$NODE_VERSION"
-          echo "::set-output name=csp_header::$CSP_HEADER"
-          echo "::set-output name=cd_role::$CD_ROLE"
-          echo "::set-output name=cfn_role::$CFN_ROLE"
-          echo "::set-output name=cert_arn::$CERT_ARN"
-          echo "::set-output name=domain::$BASE_DOMAIN"
-          echo "::set-output name=subdomain::$SUBDOMAIN"
-          echo "::set-output name=product::$PRODUCT"
-          echo "::set-output name=stackname::$STACKNAME"
+          echo "version=$NODE_VERSION" >> $GITHUB_OUTPUT
+          echo "csp_header=$CSP_HEADER" >> $GITHUB_OUTPUT
+          echo "cd_role=$CD_ROLE" >> $GITHUB_OUTPUT
+          echo "cfn_role=$CFN_ROLE" >> $GITHUB_OUTPUT
+          echo "cert_arn=$CERT_ARN" >> $GITHUB_OUTPUT
+          echo "domain=$BASE_DOMAIN" >> $GITHUB_OUTPUT
+          echo "subdomain=$SUBDOMAIN" >> $GITHUB_OUTPUT
+          echo "product=$PRODUCT" >> $GITHUB_OUTPUT
+          echo "stackname=$STACKNAME" >> $GITHUB_OUTPUT
 
       - name: Setup Node
         uses: actions/setup-node@v1
@@ -124,12 +124,12 @@ jobs:
           if aws cloudformation describe-stacks --stack-name $STACKNAME; then
             PARAMETER_CSP=$(aws cloudformation describe-stacks --stack-name $STACKNAME --query "Stacks[0].Parameters[?ParameterKey=='CSPHeaderValue'].ParameterValue" --output text)
             if [[ "$PARAMETER_CSP" == "${{ steps.config.outputs.csp_header }}" ]]; then
-              echo "::set-output name=create_or_update_stack::0";
+              echo "create_or_update_stack=0" >> $GITHUB_OUTPUT;
             else
-              echo "::set-output name=create_or_update_stack::1";
+              echo "create_or_update_stack=1" >> $GITHUB_OUTPUT;
             fi
           else
-            echo "::set-output name=create_or_update_stack::1";
+            echo "create_or_update_stack=1" >> $GITHUB_OUTPUT;
           fi
 
       - name: Set up S3-Cloudfront

--- a/.github/workflows/teardown-frontend.yml
+++ b/.github/workflows/teardown-frontend.yml
@@ -27,8 +27,8 @@ jobs:
           fi
           source environments/review.env
           STACKNAME=${PRODUCT}-pr-${{ github.event.pull_request.number }}
-          echo "::set-output name=stackname::$STACKNAME"
-          echo "::set-output name=cd_role::$CD_ROLE"
+          echo "stackname=$STACKNAME" >> $GITHUB_OUTPUT
+          echo "cd_role=$CD_ROLE" >> $GITHUB_OUTPUT
 
       - uses: strumwolf/delete-deployment-environment@v2
         with:

--- a/.github/workflows/trigger-release-pr.yml
+++ b/.github/workflows/trigger-release-pr.yml
@@ -56,7 +56,7 @@ jobs:
         uses: actions/checkout@v3
       - name: Get current date
         id: date
-        run: echo "::set-output name=date::$(date +'%d/%m/%Y')"
+        run: echo "date=$(date +'%d/%m/%Y')" >> $GITHUB_OUTPUT
       - name: Create release pull request
         uses: actions/github-script@v6
         with:


### PR DESCRIPTION
## Description

<!-- Write and explain of the changes introduced by this PR for the reviewers to fully understand -->
Replace set-output with echo "var=value" >> $GITHUB_OUTPUT
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

## Checklist

<!-- Please check everything that applies: -->

- [X] I have reviewed my code and checked that there are no unrelated changes in this pull request (old patches, accidental config files, etc)
- [ ] I have created at least one test case for the changes I have made
- [ ] I have updated the documentation (**SwaggerHub**, **README.md**, **Wiki**, etc.) for the changes I have made
