### PR TITLE
[DEVOPS-865] Enhance deploy workflow based on ticket comments

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -10,13 +10,16 @@ on:
         required: true
         type: string
       environment_suffix:
-        required: true
+        required: false
         type: string
       dynamic_cf_parameters:
         required: false
         type: string
       main_cf_template:
         required: false
+        type: string
+      stack_name:
+        required: true
         type: string
 
 jobs:
@@ -62,7 +65,13 @@ jobs:
           echo "AWS_ACCOUNT_NAME=$AWS_ACCOUNT_NAME" >> $GITHUB_OUTPUT
           echo "AWS_CD_ROLE=$AWS_CD_ROLE" >> $GITHUB_OUTPUT
           echo "AWS_CF_ROLE=$AWS_CF_ROLE" >> $GITHUB_OUTPUT
-          echo "STACK_NAME=$( echo $ProductName-${{ inputs.environment_suffix }} )" >> $GITHUB_OUTPUT
+
+          INPUT_ENV_SUFFIX=${{ inputs.environment_suffix }}
+          if [[ -z $INPUT_ENV_SUFFIX ]]; then
+            echo "STACK_NAME=$( echo ${{ inputs.stack_name }} )" >> $GITHUB_OUTPUT
+          else
+            echo "STACK_NAME=$( echo ${{ inputs.stack_name }}-${{ inputs.environment_suffix }} )" >> $GITHUB_OUTPUT
+          fi
 
       - name: Configure AWS Credentials
         id: configure-aws-creds

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -13,7 +13,10 @@ on:
         required: true
         type: string
       dynamic_cf_parameters:
-        required: true
+        required: false
+        type: string
+      main_cf_template:
+        required: false
         type: string
 
 jobs:
@@ -63,17 +66,31 @@ jobs:
           aws-region: ${{ steps.extract-deployment-envs.outputs.AWS_REGION }}
 
       - name: Combine CloudFormation Parameters
+        Description: Merge 2 json inputs, and create a key-value string for SAM deployment, like "key1=value1 key2=value2" 
         id: combine-cf-parameters
         run: |
-          echo ${{ inputs.dynamic_cf_parameters }} | jq '.' >> dynamic_cf_parameters.json
-          # Merge 2 json inputs, and create a key-value string, like "key1=value1,key2=value2" 
-          echo "SAM_PARAMETERS=$( jq '. + input' infra/environments/${{ inputs.environment_id }}_cf_parameters.json dynamic_cf_parameters.json | jq -r 'to_entries | map(.key + "=" + .value) | join(" ")')" >> $GITHUB_OUTPUT
+          DYNAMIC_CF_PARAMETERS=${{ inputs.dynamic_cf_parameters }}
+          if [[ -z $DYNAMIC_CF_PARAMETERS ]]; then
+            #Filter out the Parameters parent key if it exists and then produce SAM parameters
+            echo "SAM_PARAMETERS=$( jq '. | if has("Parameters") then .Parameters else . end' infra/environments/${{ inputs.environment_id }}_cf_parameters.json | jq -r 'to_entries | map(.key + "=" + .value) | join(" ")')"
+          else
+            #Filter out the Parameters parent key if it exists, combine with dynamic parameters and then produce SAM parameters
+            jq '. | if has("Parameters") then .Parameters else . end' infra/environments/${{ inputs.environment_id }}_cf_parameters.json >> temp_cf_parameters.json
+            echo ${{ inputs.dynamic_cf_parameters }} | jq '.' >> dynamic_cf_parameters.json
+            echo "SAM_PARAMETERS=$( jq '. + input' temp_cf_parameters.json dynamic_cf_parameters.json | jq -r 'to_entries | map(.key + "=" + .value) | join(" ")')" >> $GITHUB_OUTPUT
+          fi
 
       - name: Build and Deploy SAM
         id: sam-deploy
         run: |
           cat infra/samconfig.toml
-          sam build -t infra/aws-deploy.yml
+          
+          MAIN_CF_TEMPLATE=${{ inputs.main_cf_template }}
+          if [[ -z $MAIN_CF_TEMPLATE ]]; then
+            sam build -t infra/aws-deploy.yml
+          else
+            sam build -t infra/${{ inputs.main_cf_template }}
+
           sam deploy \
           --config-file infra/samconfig.toml \
           --config-env ${{ inputs.environment_id }} \

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -40,7 +40,13 @@ jobs:
         id: extract-deployment-envs
         run: |
           set -o allexport
-          source infra/environments/common.env
+          
+          if [ -f "infra/environments/common.env" ]; then
+            source infra/environments/common.env
+          else
+            echo "No common.env file has been found. Disregarding it."
+          fi
+
           source infra/environments/${{ inputs.environment_id }}.env
 
           if [[ -z $ProductName || -z $AWS_REGION || -z $AWS_ACCOUNT_ID || -z $AWS_ACCOUNT_NAME || -z $AWS_CD_ROLE || -z $AWS_CF_ROLE ]]; then

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -89,7 +89,7 @@ jobs:
           if [[ -z $MAIN_CF_TEMPLATE ]]; then
             sam build -t infra/aws-deploy.yml
           else
-            sam build -t infra/${{ inputs.main_cf_template }}
+            sam build -t ${{ inputs.main_cf_template }}
 
           sam deploy \
           --config-file infra/samconfig.toml \

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ with:
 The workflow expects a specific folder structure and naming scheme:
 * A main folder called "infra" that includes all the CloudFormation templates including the root/parent/main CloudFormation template and the samconfig.toml
 * The root/parent/main CloudFormation template, must be named "aws-deploy.yml". If there is a need to not use that one, another one can be passed through the "main_cf_template" workflow input that overwrites the default value. If it's a local file, the full file path must be provided.
-* A subfolder "infra/environments" that includes all the .env files and .json files that correspond with the environment_id naming scheme, plus, a "common.env" for global variables across environments, like the ProductName or even aws-region if it's the same across all different environments.
+* A subfolder "infra/environments" that includes all the .env files and .json files that correspond with the environment_id naming scheme, plus, an optional "common.env" file for global variables across environments, like the ProductName or even aws-region if it's the same across all different environments.
 * There should be only one samconfig file, called "samconfig.toml", with all the environment_types specified inside
 
 The infra's folder structure MUST look something like this:

--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ deploy:
     environment_id: review
     environment_suffix: ${{ github.event.pull_request.number }}
     dynamic_cf_parameters: ${{ needs.build_app.outputs.json-string }}
+    stack_name: "airflow-example"
 ```
 * For the job name, you can leave it as shown above
 * The "needs" section depends on your CI's job names and job prerequisites
@@ -92,9 +93,10 @@ deploy:
 For the reusable workflow's inputs, there are 4 required ones:
 * python_version: The python version that will be used for workflow's commands
 * environment_id: The environment_id MUST match a pre-existing environment file and a pre-existing <environment_id>_cf_parameters.json, e.g. infra/environments/production.env + infra/environments/production_cf_parameters.json + environment_id: production.
-* environment_suffix: The suffix that is added to the product name ( which together form the stack name ) and some of the stack's resources as an identification. The recommendation is a) For review environments, to add the Pull Request number, b) for other environment types, to match the environment_id. Having said that, these are recommendations and anything meaningful can be added.
+* environment_suffix: (OPTIONAL) The suffix that is added to the stack name. The recommendation is a) For review environments, to add the Pull Request number, b) for other environment types, to match the environment_id. Having said that, these are recommendations and anything meaningful can be added.
 * dynamic_cf_parameters: (OPTIONAL) A stringified list of additional parameters that can be adedd to the sam deploy command. You can easily create such a string with a command like this:
 * main_cf_template: (OPTIONAL) The default file path of the main CloudFormation template is infra/aws-deploy.yml. If there is a need for a different filename, a file in a different path in the repo or a file from an S3 URI, you can overwrite by providing here the custom template.
+* stack_name: The name of the CloudFormation stack. If there is an environment_suffix, that is added to the end of the stack_name.
 ```
 app_image=hello
 test_custom_var_1=123456789012.dkr.ecr.us-east-1.amazonaws.com/test/flower:latest

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ For the reusable workflow's inputs, there are 4 required ones:
 * environment_id: The environment_id MUST match a pre-existing environment file and a pre-existing <environment_id>_cf_parameters.json, e.g. infra/environments/production.env + infra/environments/production_cf_parameters.json + environment_id: production.
 * environment_suffix: (OPTIONAL) The suffix that is added to the stack name. The recommendation is a) For review environments, to add the Pull Request number, b) for other environment types, to match the environment_id. Having said that, these are recommendations and anything meaningful can be added.
 * dynamic_cf_parameters: (OPTIONAL) A stringified list of additional parameters that can be adedd to the sam deploy command. You can easily create such a string with a command like this:
-* main_cf_template: (OPTIONAL) The default file path of the main CloudFormation template is infra/aws-deploy.yml. If there is a need for a different filename, a file in a different path in the repo or a file from an S3 URI, you can overwrite by providing here the custom template.
+* main_cf_template: (OPTIONAL) The default file path of the main CloudFormation template is infra/aws-deploy.yml. If there is a need for a different filename or a file in a different path in the repo you can overwrite by providing here the custom template.
 * stack_name: The name of the CloudFormation stack. If there is an environment_suffix, that is added to the end of the stack_name.
 ```
 app_image=hello

--- a/README.md
+++ b/README.md
@@ -93,7 +93,8 @@ For the reusable workflow's inputs, there are 4 required ones:
 * python_version: The python version that will be used for workflow's commands
 * environment_id: The environment_id MUST match a pre-existing environment file and a pre-existing <environment_id>_cf_parameters.json, e.g. infra/environments/production.env + infra/environments/production_cf_parameters.json + environment_id: production.
 * environment_suffix: The suffix that is added to the product name ( which together form the stack name ) and some of the stack's resources as an identification. The recommendation is a) For review environments, to add the Pull Request number, b) for other environment types, to match the environment_id. Having said that, these are recommendations and anything meaningful can be added.
-* dynamic_cf_parameters: A stringified list of additional parameters that can be adedd to the sam deploy command. You can easily create such a string with a command like this:
+* dynamic_cf_parameters: (OPTIONAL) A stringified list of additional parameters that can be adedd to the sam deploy command. You can easily create such a string with a command like this:
+* main_cf_template: (OPTIONAL) The default file path of the main CloudFormation template is infra/aws-deploy.yml. If there is a need for a different filename, a file in a different path in the repo or a file from an S3 URI, you can overwrite by providing here the custom template.
 ```
 app_image=hello
 test_custom_var_1=123456789012.dkr.ecr.us-east-1.amazonaws.com/test/flower:latest
@@ -114,7 +115,7 @@ with:
 
 The workflow expects a specific folder structure and naming scheme:
 * A main folder called "infra" that includes all the CloudFormation templates including the root/parent/main CloudFormation template and the samconfig.toml
-* The root/parent/main CloudFormation template, must be named "aws-deploy.yml"
+* The root/parent/main CloudFormation template, must be named "aws-deploy.yml". If there is a need to not use that one, another one can be passed through the "main_cf_template" workflow input that overwrites the default value. If it's a local file, the full file path must be provided.
 * A subfolder "infra/environments" that includes all the .env files and .json files that correspond with the environment_id naming scheme, plus, a "common.env" for global variables across environments, like the ProductName or even aws-region if it's the same across all different environments.
 * There should be only one samconfig file, called "samconfig.toml", with all the environment_types specified inside
 
@@ -139,5 +140,3 @@ total 36K
 -rw-r--r-- 1 user user  236 Nov  2 18:16 staging.env
 -rw-r--r-- 1 user user 1.2K Nov  9 16:44 staging_cf_parameters.json
 ```
-
-


### PR DESCRIPTION
Address the following issues:
- Instead of always using the aws-deploy.yml file for deployment, an existing CloudFormation template should be allowed (S3 bucket URL or local) 
- Make common.env file optional  (if it’s not already)
- Make dynamic parameters optional
- Make env_parameters.json compatible with aws cloudformatio deploy json parameters file

Modifications/Enhancements:
1. Main template has been made optional and without file extension
2. Common environment file is now optional
3. Dynamic Parameters workflow input has been made optional
4. Environmental parameters now support both a key-value json format and a cloudformation/codepipeline format with a parent "Parameters" key