### PR TITLE
fix: update always-auth for new node 18.14 and support old

### DIFF
--- a/.github/workflows/deploy-frontend.yml
+++ b/.github/workflows/deploy-frontend.yml
@@ -96,7 +96,7 @@ jobs:
         run: |
           npm config set //npm.pkg.github.com/:_authToken ${{ secrets.ORG_PGP_TOKEN }}
           npm config set @orfium:registry https://npm.pkg.github.com
-          npm config set always-auth true
+          npm config set always-auth true || echo "This fails for versions > 18.13"
           yarn config set @orfium:registry https://npm.pkg.github.com
           yarn config set registry https://npm.pkg.github.com
 


### PR DESCRIPTION
## Description

This PR add the support for new node 18.14 that introduce latest `npm` `9.3.1`. By adding the latest npm, the `always-auth` is no longer used and is set by default. That is why we silently fail with a message

For older versions with older `npm` this should work as expected


<!-- Write and explain of the changes introduced by this PR for the reviewers to fully understand -->

![image](https://user-images.githubusercontent.com/6433679/217843108-c2d515c9-23ad-4cd0-abe5-6439b9adde5b.png)

https://github.com/nodejs/node/blob/main/doc/changelogs/CHANGELOG_V18.md#18.14.0

## Checklist

<!-- Please check everything that applies: -->

- [x] I have reviewed my code and checked that there are no unrelated changes in this pull request (old patches, accidental config files, etc)
- [ ] I have created at least one test case for the changes I have made
- [ ] I have updated the documentation (**SwaggerHub**, **README.md**, **Wiki**, etc.) for the changes I have made
