### PR TITLE
fix: Allow more than one essential containers [RC-1820]

### DIFF
--- a/.github/workflows/run-command.yml
+++ b/.github/workflows/run-command.yml
@@ -69,10 +69,6 @@ jobs:
                   taskDefinition=service["taskDefinition"]
               )["taskDefinition"]["containerDefinitions"]
               essential_containers = [x for x in container_definitions if x["essential"]]
-              if (num_essential_containers := len(essential_containers)) != 1:
-                  raise Exception(
-                      f"Expected only one essential container, found {num_essential_containers}"
-                  )
               container_name = essential_containers[0]["name"]
               return container_name
 


### PR DESCRIPTION
# BE

## Description

We have more than one essential containers in MRC. This causes the `run-command` to fail. Since we always use the first container found and no other validation is made, we might want to allow any number of essential or add another validation.
Failing CI [here](https://github.com/Orfium/asset-service/actions/runs/4323859952/jobs/7548085823) 

Passing CI [here](https://github.com/Orfium/asset-service/actions/runs/4324264099) 
## Checklist

<!-- Please check everything that applies: -->

- [ ] I have reviewed my code and checked that there are no unrelated changes in this pull request (old patches, accidental config files, etc)
- [ ] I have created at least one test case for the changes I have made
- [ ] I have updated the documentation (**SwaggerHub**, **README.md**, **Wiki**, etc.) for the changes I have made
