### PR TITLE
feat: add caching in reusable workflows on build and push step

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -60,7 +60,14 @@ jobs:
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v3
-      
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+        # # We are overriding the default buildkit version being used by Buildx. We need buildkit >= 12.0 and currently BuildX
+        # supports v0.11.6 https://github.com/docker/buildx/blob/b8739d74417f86aa8fc9aafb830a8ba656bdef0e/Dockerfile#L9.
+        # We should for any updates on buildx and on the setup-buildx-action itself.
+        with:
+          driver-opts: |
+            image=moby/buildkit:v0.12.0
       - name: Set deployment env
         id: set-environment
         run: |
@@ -127,11 +134,26 @@ jobs:
           echo "CODEARTIFACT_TOKEN_PROD=$token" >> "$GITHUB_ENV"
       
       - name: Build And Push Docker Image
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v4
+        if: ${{ (github.event_name != 'pull_request') }}
         with:
           push: true
           tags: ${{ env.ECR_REGISTRY }}:${{ github.sha }}
-          cache-to: "type=inline"
+          cache-from: ${{ env.ECR_REGISTRY }}:stable
+          cache-to: type=registry,ref=${{ env.ECR_REGISTRY }}:stable,mode=max,image-manifest=true,oci-mediatypes=true
+          target: production
+          secrets: |
+            CODEARTIFACT_TOKEN_DEV=${{ env.CODEARTIFACT_TOKEN_DEV }}
+            CODEARTIFACT_TOKEN_PROD=${{ env.CODEARTIFACT_TOKEN_PROD }}
+          
+      - name: Build And Push Docker Image PR
+        uses: docker/build-push-action@v4
+        if: ${{ (github.event_name == 'pull_request') }}
+        with:
+          push: true
+          tags: ${{ env.ECR_REGISTRY }}:${{ github.sha }}
+          cache-from: ${{ env.ECR_REGISTRY }}:latest
+          cache-to: type=registry,ref=${{ env.ECR_REGISTRY }}:latest,mode=max,image-manifest=true,oci-mediatypes=true
           target: production
           secrets: |
             CODEARTIFACT_TOKEN_DEV=${{ env.CODEARTIFACT_TOKEN_DEV }}


### PR DESCRIPTION
# Orfium GitHub Actions

## Description
[BEC-301](https://orfium.atlassian.net/browse/BEC-301)
<!-- Write and explain of the changes introduced by this PR for the reviewers to fully understand or link the related JIRA ticket-->

The `build-and-push` action will now push instead of the commit sha only to the `stable` tag when something is merge to main. This image can then be used on next deployments as a caching layer to speedup the build process.

## Checklist

<!-- Please check everything that applies: -->

- [x] I have reviewed my code and checked that there are no unrelated changes in this pull request
- [x] I have created a JIRA ticket describing the purpose of this pull request
- [x] I have checked if the changes to the templates are breaking or have contacted the DevOps team for feedback
- [x] I have updated the template with the Actionlint Format guidelines: [Actionlint](https://github.com/rhysd/actionlint#readme). Information on how to do that are provided on the CONTRIBUTING.md file under docs/ folder.

[BEC-301]: https://orfium.atlassian.net/browse/BEC-301?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ