### PR TITLE
ci/add e2e tests report visualisation [QA-518]

### DIFF
--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -4,7 +4,10 @@ on:
       BUILDX_LOCAL_CACHE_DIR:
         required: false
         type: string
-      TEST_RESULTS_PATH :
+      API_TEST_RESULTS_PATH:
+        required: false
+        type: string
+      UI_TEST_RESULTS_PATH:
         required: false
         type: string
       RUN_UI_TESTS:
@@ -91,7 +94,7 @@ jobs:
         uses: dorny/test-reporter@v1
         with:
           name: E2E Test Reports
-          path: ${{ github.workspace }}/${{ inputs.TEST_RESULTS_PATH }}   # Concatenated Workspace absolute path with the path to the test results
+          path: ${{ github.workspace }}/${{ inputs.API_TEST_RESULTS_PATH }},${{ github.workspace }}/${{ inputs.UI_TEST_RESULTS_PATH }}   # Concatenated Workspace absolute path with the path to the test results
           reporter: java-junit # the proper reporter for test results that are generated with JUnit-XML format. We must make this dynamic if we want to support other formats.
           fail-on-error: false # we want the action to run even if the tests fail. If this is set to true, we won't have reports if a test fails
 

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -94,7 +94,7 @@ jobs:
         uses: dorny/test-reporter@v1
         with:
           name: E2E Test Reports
-          path: ${{ github.workspace }}/${{ inputs.API_TEST_RESULTS_PATH }},${{ github.workspace }}/${{ inputs.UI_TEST_RESULTS_PATH }}   # Concatenated Workspace absolute path with the path to the test results
+          path: ${{ github.workspace }}/${{ inputs.API_TEST_RESULTS_PATH }},${{ github.workspace }}/${{ inputs.UI_TEST_RESULTS_PATH }} # Coma separated list of paths to test results, all matched result files must be of the same format
           reporter: java-junit # the proper reporter for test results that are generated with JUnit-XML format. We must make this dynamic if we want to support other formats.
           fail-on-error: false # we want the action to run even if the tests fail. If this is set to true, we won't have reports if a test fails
 

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -91,9 +91,9 @@ jobs:
         uses: dorny/test-reporter@v1
         with:
           name: E2E Test Reports
-          path: ${{ github.workspace }}/${{ inputs.TEST_RESULTS_PATH }}   # Path to test results
-          reporter: java-junit
-          fail-on-error: false
+          path: ${{ github.workspace }}/${{ inputs.TEST_RESULTS_PATH }}   # Concatenated Workspace absolute path with the path to the test results
+          reporter: java-junit # the proper reporter for test results that are generated with JUnit-XML format. We must make this dynamic if we want to support other formats.
+          fail-on-error: false # we want the action to run even if the tests fail. If this is set to true, we won't have reports if a test fails
 
       - name: Tear down the Stack
         run: make down-volumes

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -93,6 +93,7 @@ jobs:
           name: E2E Test Reports
           path: ${{ inputs.TEST_RESULTS_PATH }}   # Path to test results
           reporter: java-junit
+          fail-on-error: false
 
       - name: Tear down the Stack
         run: make down-volumes

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -4,6 +4,9 @@ on:
       BUILDX_LOCAL_CACHE_DIR:
         required: false
         type: string
+      TEST_RESULTS_PATH :
+        required: false
+        type: string
       RUN_UI_TESTS:
         required: false
         type: boolean
@@ -78,6 +81,14 @@ jobs:
         env:
           TESTRAIL_PASSWORD: ${{ secrets.TESTRAIL_PASSWORD }}
         run: make testrail-results
+
+      - name: visualise-e2e-test-reports
+        if: always()
+        uses: dorny/test-reporter@v1
+        with:
+          name: E2E Test Reports
+          path: ${{ inputs.TEST_RESULTS_PATH }}   # Path to test results
+          reporter: java-junit
 
       - name: Tear down the Stack
         run: make down-volumes

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -91,7 +91,7 @@ jobs:
         uses: dorny/test-reporter@v1
         with:
           name: E2E Test Reports
-          path: ${{ inputs.TEST_RESULTS_PATH }}   # Path to test results
+          path: ${{ github.workspace }}/${{ inputs.TEST_RESULTS_PATH }}   # Path to test results
           reporter: java-junit
           fail-on-error: false
 

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -76,10 +76,12 @@ jobs:
           tags: ${{ github.event.repository.name }}
 
       - name: Run End to End API tests
+        id: e2e-api-tests
         if: ${{ inputs.RUN_API_TESTS }}
         run: make e2e-api-tests
 
       - name: Run End to End UI tests
+        id: e2e-ui-tests
         if: ${{ inputs.RUN_UI_TESTS }}
         run: make e2e-ui-tests
 
@@ -90,7 +92,7 @@ jobs:
         run: make testrail-results
 
       - name: visualise-e2e-test-reports
-        if: always()
+        if: steps.e2e-api-tests.outcome != 'skipped' || steps.e2e-ui-tests.outcome != 'skipped'
         uses: dorny/test-reporter@v1
         with:
           name: E2E Test Reports

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -32,6 +32,10 @@ env:
 jobs:
   end-to-end-api-tests:
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+      checks: write
     steps:
       - name: Checkout Code Repository
         uses: actions/checkout@v3

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -96,7 +96,7 @@ jobs:
         uses: dorny/test-reporter@v1
         with:
           name: E2E Test Reports
-          path: ${{ github.workspace }}/${{ inputs.API_TEST_RESULTS_PATH }},${{ github.workspace }}/${{ inputs.UI_TEST_RESULTS_PATH }} # Coma separated list of paths to test results, all matched result files must be of the same format
+          path: ${{ github.workspace }}/${{ inputs.API_TEST_RESULTS_PATH }},${{ github.workspace }}/${{ inputs.UI_TEST_RESULTS_PATH }} # Comma separated list of paths to test results, all matched result files must be of the same format
           reporter: java-junit # the proper reporter for test results that are generated with JUnit-XML format. We must make this dynamic if we want to support other formats.
           fail-on-error: false # we want the action to run even if the tests fail. If this is set to true, we won't have reports if a test fails
 


### PR DESCRIPTION
# Orfium GitHub Actions

## Description

- Add test report viewer in e2e tests reusable action (example https://github.com/Orfium/universal-catalog-mapper/actions/runs/4894297717/jobs/8738554725)

## Checklist

<!-- Please check everything that applies: -->

- [x] I have reviewed my code and checked that there are no unrelated changes in this pull request
- [x] I have created a JIRA ticket describing the purpose of this pull request
- [x] I have checked if the changes to the templates are breaking or have contacted the DevOps team for feedback
- [x] I have updated the template with the Actionlint Format guidelines: [Actionlint](https://github.com/rhysd/actionlint#readme). Information on how to do that are provided on the CONTRIBUTING.md file under docs/ folder.