### PR TITLE
fix: fix e2e-tests reports when a step fails [CDT-245]

### DIFF
--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -120,7 +120,8 @@ jobs:
         run: make testrail-results
 
       - name: visualise-e2e-test-reports
-        if: steps.e2e-api-tests.outcome != 'skipped' || steps.e2e-ui-tests.outcome != 'skipped'
+        # We leverage the fact that GitHub Actions sets the outcome to null for steps that have not run
+        if: steps.e2e-api-tests.conclusion != null || steps.e2e-ui-tests.conclusion != null
         uses: dorny/test-reporter@v1
         with:
           name: E2E Test Reports

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -121,7 +121,7 @@ jobs:
 
       - name: visualise-e2e-test-reports
         # We leverage the fact that GitHub Actions sets the outcome to null for steps that have not run
-        if: steps.e2e-api-tests.conclusion != null || steps.e2e-ui-tests.conclusion != null
+        if: always() && (steps.e2e-api-tests.outcome != null || steps.e2e-ui-tests.outcome != null)
         uses: dorny/test-reporter@v1
         with:
           name: E2E Test Reports


### PR DESCRIPTION
# Orfium GitHub Actions

## Description

- Handle cases where previous steps have failed. In those cases the reporting step was skipped (ie https://github.com/Orfium/universal-catalog-mapper/actions/runs/4990857929/jobs/8936890476) 

example: https://github.com/Orfium/universal-catalog-mapper/actions/runs/4992736350/jobs/8941068045

## Checklist

<!-- Please check everything that applies: -->

- [x] I have reviewed my code and checked that there are no unrelated changes in this pull request
- [x] I have created a JIRA ticket describing the purpose of this pull request
- [x] I have checked if the changes to the templates are breaking or have contacted the DevOps team for feedback
- [x] I have updated the template with the Actionlint Format guidelines: [Actionlint](https://github.com/rhysd/actionlint#readme). Information on how to do that are provided on the CONTRIBUTING.md file under docs/ folder.