### PR TITLE
fix: publish swaggerhub projects as private

### DIFF
--- a/.github/workflows/swaggerhub.yml
+++ b/.github/workflows/swaggerhub.yml
@@ -10,6 +10,11 @@ on:
       codeartifact_encrypted_token_prod:
         required: false
         type: string
+      is_private:
+        required: false
+        type: string
+        default: true
+        description: Whether the swagger definition should be public or pricate
     secrets:
       SWAGGERHUB_TOKEN:
         required: true
@@ -89,5 +94,6 @@ jobs:
         if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/master'
         env:
           SWAGGERHUB_TOKEN: ${{ secrets.SWAGGERHUB_TOKEN }}
+          IS_PRIVATE: ${{ inputs.is_private }}
         run: |
-          curl --fail -X POST "https://api.swaggerhub.com/apis/OrfiumTeam/${{ github.event.repository.name }}" -H "Authorization: $SWAGGERHUB_TOKEN" -H "Content-Type: application/yaml" --data-binary "@test.yaml"
+          curl --fail -X POST "https://api.swaggerhub.com/apis/OrfiumTeam/${{ github.event.repository.name }}?isPrivate=$IS_PRIVATE&force=true" -H "Authorization: $SWAGGERHUB_TOKEN" -H "Content-Type: application/yaml" --data-binary "@test.yaml"


### PR DESCRIPTION
# Orfium GitHub Actions

## Description
[BEC-337](https://orfium.atlassian.net/browse/BEC-337)
<!-- Write and explain of the changes introduced by this PR for the reviewers to fully understand or link the related JIRA ticket-->

## Checklist

<!-- Please check everything that applies: -->

- [x] I have reviewed my code and checked that there are no unrelated changes in this pull request
- [x] I have created a JIRA ticket describing the purpose of this pull request
- [x] I have checked if the changes to the templates are breaking or have contacted the DevOps team for feedback
- [x] I have updated the template with the Actionlint Format guidelines: [Actionlint](https://github.com/rhysd/actionlint#readme). Information on how to do that are provided on the CONTRIBUTING.md file under docs/ folder.

[BEC-337]: https://orfium.atlassian.net/browse/BEC-337?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ