### PR TITLE
feat: create workflow for approve and set auto merge of dependabot PRs

### DIFF
--- a/.github/workflows/dependabot-approve-and-set-auto-merge.yml
+++ b/.github/workflows/dependabot-approve-and-set-auto-merge.yml
@@ -1,0 +1,31 @@
+name: Dependabot approve and set auto merge
+on:
+  workflow_call:
+    inputs:
+      pr_url:
+        description: The PR url. It can be provided by the github.event.pull_request.html_url
+        required: true
+        type: string
+      merge_strategy:
+        description: The strategy to use for merge. Currently merge and rebase are supported
+        required: false
+        default: rebase
+        type: string
+  
+permissions:
+  contents: write
+  pull-requests: write
+  
+jobs:
+  dependabot:
+    runs-on: ubuntu-latest
+    if: ${{ github.actor == 'dependabot[bot]' }}
+    steps:
+      - name: Approve Dependabot PRs
+        run: gh pr review --approve "${{ inputs.pr_url }}"
+        env:
+          GH_TOKEN: ${{ github.token }}
+      - name: Enable auto-merge for Dependabot PRs
+        run: gh pr merge --auto --"${{ inputs.merge_strategy }}" "${{ inputs.pr_url }}"
+        env:
+          GH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
# Orfium GitHub Actions

## Description
[BEC-421](https://orfium.atlassian.net/browse/BEC-421)
<!-- Write and explain of the changes introduced by this PR for the reviewers to fully understand or link the related JIRA ticket-->

Create a reusable workflow that will check if the PR is opened from dependabot[bot] or github-actions[bot] and automatically approve it and set it for automerge once the branch protection guidelines are OK.

Workflow has been tested in https://github.com/Orfium/fastapi-orfium-utils/pull/140 and the pipeline is https://github.com/Orfium/fastapi-orfium-utils/actions/runs/6308938765.

We plan to use it in libraries and not products in order to automatically merge dependabot PRs. After all, all we do is to check the pipeline and manually merge

## Checklist

<!-- Please check everything that applies: -->

- [x] I have reviewed my code and checked that there are no unrelated changes in this pull request
- [x] I have created a JIRA ticket describing the purpose of this pull request
- [x] I have checked if the changes to the templates are breaking or have contacted the DevOps team for feedback
- [x] I have updated the template with the Actionlint Format guidelines: [Actionlint](https://github.com/rhysd/actionlint#readme). Information on how to do that are provided on the CONTRIBUTING.md file under docs/ folder.

[BEC-421]: https://orfium.atlassian.net/browse/BEC-421?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ