### PR TITLE
chore: replace TESTRAIL_PASSWORD with TESTRAIL_CI_API_KEY [QA-598]

### DIFF
--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -42,7 +42,7 @@ on:
         required: false
         type: string
     secrets:
-      TESTRAIL_PASSWORD:
+      TESTRAIL_CI_API_KEY:
         description: Password for Orfium's TestRail account
         required: false
       GPG_CODEARTIFACT_TOKEN_PASSPHRASE:
@@ -144,7 +144,7 @@ jobs:
       - name: Publish test results to TestRail
         if: always() && inputs.PUBLISH_TESTRAIL_RESULTS
         env:
-          TESTRAIL_PASSWORD: ${{ secrets.TESTRAIL_PASSWORD }}
+          TESTRAIL_CI_API_KEY: ${{ secrets.TESTRAIL_CI_API_KEY }}
         run: make testrail-results
 
       - name: visualise-e2e-test-reports


### PR DESCRIPTION
# Orfium GitHub Actions

## Description

Update all references for Testrail Password and replace it with Testrail CI API key so that when password rotation takes place in Testrail, our CI jobs are not affected.
A new global GitHub secret has been added in GitHub named `TESTRAIL_CI_API_KEY`
The same secret has also been added as a global Jenkins credential.

[Jira ticket QA-598](https://orfium.atlassian.net/browse/QA-598)

## Checklist

<!-- Please check everything that applies: -->

- [ ] I have reviewed my code and checked that there are no unrelated changes in this pull request
- [ ] I have created a JIRA ticket describing the purpose of this pull request
- [ ] I have checked if the changes to the templates are breaking or have contacted the DevOps team for feedback
- [ ] I have updated the template with the Actionlint Format guidelines: [Actionlint](https://github.com/rhysd/actionlint#readme). Information on how to do that are provided on the CONTRIBUTING.md file under docs/ folder.