### PR TITLE
fix: use latest moby buildkit version

### DIFF
--- a/.github/workflows/build-and-push-v2.yml
+++ b/.github/workflows/build-and-push-v2.yml
@@ -70,12 +70,9 @@ jobs:
           
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
-        # # We are overriding the default buildkit version being used by Buildx. We need buildkit >= 12.0 and currently BuildX
-        # supports v0.11.6 https://github.com/docker/buildx/blob/b8739d74417f86aa8fc9aafb830a8ba656bdef0e/Dockerfile#L9.
-        # We should for any updates on buildx and on the setup-buildx-action itself.
         with:
           driver-opts: |
-            image=moby/buildkit:v0.12.0
+            image=moby/buildkit:master
 
       - name: Configure AWS Credentials
         id: configure-aws-creds

--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -62,12 +62,9 @@ jobs:
         uses: actions/checkout@v4
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
-        # # We are overriding the default buildkit version being used by Buildx. We need buildkit >= 12.0 and currently BuildX
-        # supports v0.11.6 https://github.com/docker/buildx/blob/b8739d74417f86aa8fc9aafb830a8ba656bdef0e/Dockerfile#L9.
-        # We should for any updates on buildx and on the setup-buildx-action itself.
         with:
           driver-opts: |
-            image=moby/buildkit:v0.12.0
+            image=moby/buildkit:master
       - name: Set deployment env
         id: set-environment
         run: |

--- a/.github/workflows/build-local-images-v2.yml
+++ b/.github/workflows/build-local-images-v2.yml
@@ -69,12 +69,9 @@ jobs:
           
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
-        # # We are overriding the default buildkit version being used by Buildx. We need buildkit >= 12.0 and currently BuildX
-        # supports v0.11.6 https://github.com/docker/buildx/blob/b8739d74417f86aa8fc9aafb830a8ba656bdef0e/Dockerfile#L9.
-        # We should for any updates on buildx and on the setup-buildx-action itself.
         with:
           driver-opts: |
-            image=moby/buildkit:v0.12.0
+            image=moby/buildkit:master
             
       - name: Configure AWS Credentials
         id: configure-aws-creds

--- a/.github/workflows/build-local-images.yml
+++ b/.github/workflows/build-local-images.yml
@@ -45,12 +45,9 @@ jobs:
           ref: ${{ github.sha }}
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
-        # # We are overriding the default buildkit version being used by Buildx. We need buildkit >= 12.0 and currently BuildX
-        # supports v0.11.6 https://github.com/docker/buildx/blob/b8739d74417f86aa8fc9aafb830a8ba656bdef0e/Dockerfile#L9.
-        # We should for any updates on buildx and on the setup-buildx-action itself.
         with:
           driver-opts: |
-            image=moby/buildkit:v0.12.0
+            image=moby/buildkit:master
       - name: Set deployment env
         id: set-environment
         run: |

--- a/.github/workflows/precommit.yml
+++ b/.github/workflows/precommit.yml
@@ -30,6 +30,9 @@ jobs:
       - name: Set up Docker Buildx
         id: buildx
         uses: docker/setup-buildx-action@v3
+        with:
+          driver-opts: |
+            image=moby/buildkit:master
       
       - name: Set up Local Cache for Docker layers
         if: "${{ inputs.BUILDX_LOCAL_CACHE_DIR != '' }}"

--- a/.github/workflows/swaggerhub.yml
+++ b/.github/workflows/swaggerhub.yml
@@ -35,6 +35,9 @@ jobs:
       - name: Set up Docker Buildx
         id: buildx
         uses: docker/setup-buildx-action@v3
+        with:
+          driver-opts: |
+            image=moby/buildkit:master
       
       - name: Set up Local Cache for Docker layers
         if: "${{ inputs.BUILDX_LOCAL_CACHE_DIR != '' }}"

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -67,6 +67,9 @@ jobs:
       - name: Set up Docker Buildx
         id: buildx
         uses: docker/setup-buildx-action@v3
+        with:
+          driver-opts: |
+            image=moby/buildkit:master
 
       - name: Set up Local Cache for Docker layers
         if: "${{ inputs.BUILDX_LOCAL_CACHE_DIR != '' }}"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,6 +46,9 @@ jobs:
       - name: Set up Docker Buildx
         id: buildx
         uses: docker/setup-buildx-action@v3
+        with:
+          driver-opts: |
+            image=moby/buildkit:master
 
       - name: Set up Local Cache for Docker layers
         if: "${{ inputs.BUILDX_LOCAL_CACHE_DIR != '' }}"


### PR DESCRIPTION
# Orfium GitHub Actions

## Description

<!-- Write and explain of the changes introduced by this PR for the reviewers to fully understand or link the related JIRA ticket-->
[BEC-464](https://orfium.atlassian.net/browse/BEC-464)

During the past we have pinned the version of buildkit to be used together with the [setup-build-action](https://github.com/docker/setup-buildx-action). After the issue on precommit we have identified that it is about time to unpin this one as the proper version is now being used. 

## Checklist

<!-- Please check everything that applies: -->

- [ ] I have reviewed my code and checked that there are no unrelated changes in this pull request
- [ ] I have created a JIRA ticket describing the purpose of this pull request
- [ ] I have checked if the changes to the templates are breaking or have contacted the DevOps team for feedback
- [ ] I have updated the template with the Actionlint Format guidelines: [Actionlint](https://github.com/rhysd/actionlint#readme). Information on how to do that are provided on the CONTRIBUTING.md file under docs/ folder.

[BEC-464]: https://orfium.atlassian.net/browse/BEC-464?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ