### PR TITLE
[QA-627] Add action to extract the Jira ticket ID from a PR

### DIFF
--- a/.github/workflows/extract-jira-id.yml
+++ b/.github/workflows/extract-jira-id.yml
@@ -4,7 +4,7 @@ on:
     outputs:
       jira_ticket_id:
         description: 'The extracted Jira Ticket ID'
-        value: ${{ jobs.extract_jira_ticket_id.outputs.jira_ticket_id }}
+        value: ${{ jobs.extract-jira-ticket-id.outputs.jira_ticket_id }}
 
 jobs:
   extract-jira-ticket-id:
@@ -18,27 +18,29 @@ jobs:
           fetch-depth: 0
       - name: Extract Jira ticket ID from PR
         id: extract_jira_ticket_id
+        env:
+            PR_TITLE: ${{ github.event.pull_request.title }}
         run: |
+            #!/bin/bash
             set +e
             set +o pipefail
-
+            
             jira_ticket_id=""
             
             # Check PR title
-            if [[ ${{ github.event_name }} == 'pull_request' ]]; then
-                jira_ticket_id=$(echo "${{ github.event.pull_request.title }}" | grep -oE '[A-Z]+-[0-9]+')
+            if [[ $GITHUB_EVENT_NAME == 'pull_request' ]]; then
+            jira_ticket_id=$(echo "$PR_TITLE" | grep -oE '[A-Z]+-[0-9]+')
             fi
-
+            
             # Check branch name
             if [[ -z $jira_ticket_id ]]; then
-                jira_ticket_id=$(echo "${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}" | grep -oE '[A-Z]+-[0-9]+')
+            jira_ticket_id=$(echo "${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}" | grep -oE '[A-Z]+-[0-9]+')
             fi
-
+            
             if [[ -z $jira_ticket_id ]]; then
-                echo "No Jira Ticket ID found"
+            echo "No Jira Ticket ID found"
             else
-                echo "Jira Ticket ID: $jira_ticket_id"
-                echo "jira_ticket_id=$(echo $jira_ticket_id)" >> $GITHUB_OUTPUT
+            echo "Jira Ticket ID: $jira_ticket_id"
+            echo "jira_ticket_id=$jira_ticket_id" >> "$GITHUB_OUTPUT"
             fi
         shell: bash
-        

--- a/.github/workflows/extract-jira-id.yml
+++ b/.github/workflows/extract-jira-id.yml
@@ -41,3 +41,4 @@ jobs:
                 echo "jira_ticket_id=$(echo $jira_ticket_id)" >> $GITHUB_OUTPUT
             fi
         shell: bash
+        

--- a/.github/workflows/extract-jira-id.yml
+++ b/.github/workflows/extract-jira-id.yml
@@ -1,0 +1,43 @@
+name: 'Extract Jira ticket ID from PR'
+on:
+  workflow_call:
+    outputs:
+      jira_ticket_id:
+        description: 'The extracted Jira Ticket ID'
+        value: ${{ jobs.extract_jira_ticket_id.outputs.jira_ticket_id }}
+
+jobs:
+  extract-jira-ticket-id:
+    runs-on: ubuntu-latest
+    outputs:
+      jira_ticket_id: ${{ steps.extract_jira_ticket_id.outputs.jira_ticket_id }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Extract Jira ticket ID from PR
+        id: extract_jira_ticket_id
+        run: |
+            set +e
+            set +o pipefail
+
+            jira_ticket_id=""
+            
+            # Check PR title
+            if [[ ${{ github.event_name }} == 'pull_request' ]]; then
+                jira_ticket_id=$(echo "${{ github.event.pull_request.title }}" | grep -oE '[A-Z]+-[0-9]+')
+            fi
+
+            # Check branch name
+            if [[ -z $jira_ticket_id ]]; then
+                jira_ticket_id=$(echo "${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}" | grep -oE '[A-Z]+-[0-9]+')
+            fi
+
+            if [[ -z $jira_ticket_id ]]; then
+                echo "No Jira Ticket ID found"
+            else
+                echo "Jira Ticket ID: $jira_ticket_id"
+                echo "jira_ticket_id=$(echo $jira_ticket_id)" >> $GITHUB_OUTPUT
+            fi
+        shell: bash

--- a/README.md
+++ b/README.md
@@ -162,3 +162,42 @@ The teardown reusable workflow handles the deletion of the cloudformations tack 
 You will need to feed 2 required parameters to the re-usable workflow:
 * environment_id: The environment_id, as mentioned above, MUST match a pre-existing environment file and a pre-existing <environment_id>_cf_parameters.json, e.g. environments/production.env + environments/production_cf_parameters.json + environment_id: production.
 * environment_suffix: Unlike above, here the environment suffix is mandatory, in order to extrapolate the stack-name from the combination of the ProductName and the Environment Suffix. Because that similar method is used above to create the stack name in the first place, it used again here to reliably predict the name of the stack that we want to be deleted.
+
+## Extract Jira Ticket ID from PR Action
+This GitHub Action extracts a Jira Ticket ID either from the **PR title** or the **branch name**. It's useful for automating workflows that require a Jira Ticket ID.
+
+### Ticket ID Format
+Make sure to prefix the PR title or the branch with the following format: `[A-Z]-[0-9]`  (capital letters, dash, numbers)  
+Examples:  
+`PRJ-123/my-feature-branch`  
+`[PRJ-123] This is the PR title`
+
+_anything before or after the correct format is valid_
+
+### Outputs
+
+`jira_ticket_id`: The extracted Jira Ticket ID.  
+This output can be accessed using `needs.<job_id>.outputs.jira_ticket_id`, where `<job_id>` is the ID of the job that called this action.
+
+### Usage
+
+You can use this action by referencing it in your workflow file with the `uses` keyword.  
+Let's see a couple of examples:
+
+```yaml
+name: Get the Jira ticket from a PR
+
+on:
+    pull_request:
+        types: [opened, reopened, synchronize]
+
+jobs:
+    extract-jira-ticket-id:
+        uses: Orfium/orfium-github-actions/.github/workflows/extract-jira-id.yml@master
+    use-jira-ticket-id:
+        runs-on: ubuntu-latest
+        needs: extract-jira-ticket-id
+        steps:
+            - name: Use the Jira ticket id
+              run: echo "The Jira ticket id is ${{ needs.extract-jira-ticket-id.outputs.jira_ticket_id }}"
+```


### PR DESCRIPTION
# Orfium GitHub Actions

## Description

We need to get the Jira ticket ID inside the gitHub action of the tests to link it with the TestRail reports.

This action tries to find a Jira ticket ID in the format of `PRJ-123` either in the PR title or in the branch name (in that order).
The action stores the job output in a variable called `jira_ticket_id`.

### Valid examples
|  PR title | Branch name  |
|---|---|
|  PRJ-123 My PR title | PRJ-123-my-branch-name  |
|  [PR-123] My PR title |  PRJ-123/my-branch-bane |

Practically, any character before or after the correct format is allowed.


## Checklist

<!-- Please check everything that applies: -->

- [x] I have reviewed my code and checked that there are no unrelated changes in this pull request
- [x] I have created a JIRA ticket describing the purpose of this pull request
- [x] I have checked if the changes to the templates are breaking or have contacted the DevOps team for feedback
- [ ] I have updated the template with the Actionlint Format guidelines: [Actionlint](https://github.com/rhysd/actionlint#readme). Information on how to do that are provided on the CONTRIBUTING.md file under docs/ folder.

[PR-123]: https://orfium.atlassian.net/browse/PR-123?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ