### PR TITLE
feat(e2e-tests): Remove `Publish test results to TestRail` step

### DIFF
--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -18,7 +18,7 @@ on:
         required: false
         type: boolean
         default: false
-      PUBLISH_TESTRAIL_RESULTS:
+      PUBLISH_TESTMO_RESULTS:
         required: false
         type: boolean
         default: false
@@ -42,8 +42,8 @@ on:
         required: false
         type: string
     secrets:
-      TESTRAIL_CI_API_KEY:
-        description: Password for Orfium's TestRail account
+      TESTMO_TOKEN:
+        description: Token for Orfium's Testmo account
         required: false
       GPG_CODEARTIFACT_TOKEN_PASSPHRASE:
         required: false
@@ -51,7 +51,6 @@ on:
 env:
   DOCKER_BUILDKIT: 1
   COMPOSE_DOCKER_CLI_BUILD: 1
-  TESTRAIL_USERNAME: "qa@orfium.com"
 
 jobs:
   end-to-end-api-tests:
@@ -144,11 +143,11 @@ jobs:
         if: ${{ inputs.RUN_UI_TESTS }}
         run: make e2e-ui-tests
 
-      - name: Publish test results to TestRail
-        if: always() && inputs.PUBLISH_TESTRAIL_RESULTS
+      - name: Publish test results to Testmo
+        if: always() && inputs.PUBLISH_TESTMO_RESULTS
         env:
-          TESTRAIL_CI_API_KEY: ${{ secrets.TESTRAIL_CI_API_KEY }}
-        run: make testrail-results
+          TESTMO_TOKEN: ${{secrets.TESTMO_QA_CI_API_TOKEN}}
+        run: make testmo-results
 
       - name: visualise-e2e-test-reports
         # We leverage the fact that GitHub Actions sets the outcome to null for steps that have not run

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -146,7 +146,7 @@ jobs:
       - name: Publish test results to Testmo
         if: always() && inputs.PUBLISH_TESTMO_RESULTS
         env:
-          TESTMO_TOKEN: ${{secrets.TESTMO_QA_CI_API_TOKEN}}
+          TESTMO_QA_CI_API_TOKEN: ${{secrets.TESTMO_QA_CI_API_TOKEN}}
         run: make testmo-results
 
       - name: visualise-e2e-test-reports

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -42,7 +42,7 @@ on:
         required: false
         type: string
     secrets:
-      TESTMO_TOKEN:
+      TESTMO_QA_CI_API_TOKEN:
         description: Token for Orfium's Testmo account
         required: false
       GPG_CODEARTIFACT_TOKEN_PASSPHRASE:

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -18,10 +18,6 @@ on:
         required: false
         type: boolean
         default: false
-      PUBLISH_TESTMO_RESULTS:
-        required: false
-        type: boolean
-        default: false
       codeartifact_encrypted_token_dev:
         required: false
         type: string
@@ -42,9 +38,6 @@ on:
         required: false
         type: string
     secrets:
-      TESTMO_QA_CI_API_TOKEN:
-        description: Token for Orfium's Testmo account
-        required: false
       GPG_CODEARTIFACT_TOKEN_PASSPHRASE:
         required: false
 
@@ -142,12 +135,6 @@ jobs:
         id: e2e-ui-tests
         if: ${{ inputs.RUN_UI_TESTS }}
         run: make e2e-ui-tests
-
-      - name: Publish test results to Testmo
-        if: always() && inputs.PUBLISH_TESTMO_RESULTS
-        env:
-          TESTMO_TOKEN: ${{secrets.TESTMO_QA_CI_API_TOKEN}}
-        run: make testmo-results
 
       - name: visualise-e2e-test-reports
         # We leverage the fact that GitHub Actions sets the outcome to null for steps that have not run

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -166,7 +166,7 @@ jobs:
           fi
 
       - name: Publish test results to Testmo
-        if: always() && inputs.TESTMO_RESULTS_PATH && inputs.TESTMO_PROJECT_ID && inputs.TESTMO_SOURCE_NAME && inputs.TESTMO_RUN_NAME && env.testmo-token-set
+        if: always() && inputs.TESTMO_RESULTS_PATH && inputs.TESTMO_PROJECT_ID && inputs.TESTMO_SOURCE_NAME && inputs.TESTMO_RUN_NAME && env.testmo-token-set == 'true'
         uses: Orfium/github-actions/.github/actions/publish_testmo_results@master
         with:
           project_id: ${{ inputs.TESTMO_PROJECT_ID }}

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -18,6 +18,22 @@ on:
         required: false
         type: boolean
         default: false
+      TESTMO_PROJECT_ID:
+        type: number
+        description: 'Testmo Project ID'
+        required: false
+      TESTMO_SOURCE_NAME:
+        type: string
+        description: 'Source of the tests'
+        required: false
+      TESTMO_RUN_NAME:
+        type: string
+        description: 'Name of the test run. You can provide the marker, environment and type of test run.'
+        required: false
+      TESTMO_RESULTS_PATH:
+        type: string
+        description: 'Path to the results file'
+        required: false
       codeartifact_encrypted_token_dev:
         required: false
         type: string
@@ -38,6 +54,9 @@ on:
         required: false
         type: string
     secrets:
+      TESTMO_TOKEN:
+        description: API token for Orfium's Testmo account
+        required: false
       GPG_CODEARTIFACT_TOKEN_PASSPHRASE:
         required: false
 
@@ -135,6 +154,16 @@ jobs:
         id: e2e-ui-tests
         if: ${{ inputs.RUN_UI_TESTS }}
         run: make e2e-ui-tests
+
+      - name: Publish test results to Testmo
+        if: always() && inputs.TESTMO_RESULTS_PATH
+        uses: Orfium/github-actions/.github/actions/publish_testmo_results@master
+        with:
+          project_id: ${{ inputs.TESTMO_PROJECT_ID }}
+          source: ${{ inputs.TESTMO_SOURCE_NAME }}
+          name: ${{ inputs.TESTMO_RUN_NAME }}
+          results: ${{ inputs.TESTMO_RESULTS_PATH }}
+          testmo_token: ${{ secrets.TESTMO_TOKEN }}
 
       - name: visualise-e2e-test-reports
         # We leverage the fact that GitHub Actions sets the outcome to null for steps that have not run

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -155,8 +155,18 @@ jobs:
         if: ${{ inputs.RUN_UI_TESTS }}
         run: make e2e-ui-tests
 
+      - name: Check if TESTMO_TOKEN is set
+        id: check-testmo-token
+        run: |
+          if [ -z "${{ secrets.TESTMO_TOKEN }}" ]; then
+            echo "TESTMO_TOKEN is not set. Skipping the publishing step."
+            echo "testmo-token-set=false" >> "$GITHUB_ENV"
+          else
+            echo "testmo-token-set=true" >> "$GITHUB_ENV"
+          fi
+
       - name: Publish test results to Testmo
-        if: always() && inputs.TESTMO_RESULTS_PATH && inputs.TESTMO_PROJECT_ID && inputs.TESTMO_SOURCE_NAME && inputs.TESTMO_RUN_NAME
+        if: always() && inputs.TESTMO_RESULTS_PATH && inputs.TESTMO_PROJECT_ID && inputs.TESTMO_SOURCE_NAME && inputs.TESTMO_RUN_NAME && env.testmo-token-set
         uses: Orfium/github-actions/.github/actions/publish_testmo_results@master
         with:
           project_id: ${{ inputs.TESTMO_PROJECT_ID }}

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -156,7 +156,7 @@ jobs:
         run: make e2e-ui-tests
 
       - name: Publish test results to Testmo
-        if: always() && inputs.TESTMO_RESULTS_PATH
+        if: always() && inputs.TESTMO_RESULTS_PATH && inputs.TESTMO_PROJECT_ID && inputs.TESTMO_SOURCE_NAME && inputs.TESTMO_RUN_NAME
         uses: Orfium/github-actions/.github/actions/publish_testmo_results@master
         with:
           project_id: ${{ inputs.TESTMO_PROJECT_ID }}

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -146,7 +146,7 @@ jobs:
       - name: Publish test results to Testmo
         if: always() && inputs.PUBLISH_TESTMO_RESULTS
         env:
-          TESTMO_QA_CI_API_TOKEN: ${{secrets.TESTMO_QA_CI_API_TOKEN}}
+          TESTMO_TOKEN: ${{secrets.TESTMO_QA_CI_API_TOKEN}}
         run: make testmo-results
 
       - name: visualise-e2e-test-reports


### PR DESCRIPTION
# Orfium GitHub Actions

## Description
Remove `Publish test results to TestRail` and all related secrets and mentions. 
https://orfium.atlassian.net/browse/QA-647

If the needed testmo params or the token is not provided to the reusable action the publish results to testmo step is skipped(Tested using onflict-grail)
- Token not set: https://github.com/Orfium/conflict-grail/actions/runs/9759933353/job/26937762270?pr=718
- Param missing: https://github.com/Orfium/conflict-grail/actions/runs/9759731948/job/26937370457

![image](https://github.com/Orfium/orfium-github-actions/assets/40792716/f96f2641-a777-440e-a5f0-79523424f2f4)



## Checklist

<!-- Please check everything that applies: -->

- [ ] I have reviewed my code and checked that there are no unrelated changes in this pull request
- [ ] I have created a JIRA ticket describing the purpose of this pull request
- [ ] I have checked if the changes to the templates are breaking or have contacted the DevOps team for feedback
- [ ] I have updated the template with the Actionlint Format guidelines: [Actionlint](https://github.com/rhysd/actionlint#readme). Information on how to do that are provided on the CONTRIBUTING.md file under docs/ folder.