### PR TITLE
Pass docker target from workflow calls inputs

### DIFF
--- a/.github/workflows/precommit.yml
+++ b/.github/workflows/precommit.yml
@@ -10,6 +10,11 @@ on:
       codeartifact_encrypted_token_prod:
         required: false
         type: string
+      docker_target:
+        required: false
+        type: string
+        description: This is the target of the build.
+        default: local
     secrets:
       GPG_CODEARTIFACT_TOKEN_PASSPHRASE:
         required: false
@@ -63,7 +68,7 @@ jobs:
         with:
           push: false
           load: true
-          target: local
+          target: ${{ inputs.docker_target }}
           tags: ${{ github.event.repository.name }}
           cache-from: type=local,src=${{ inputs.BUILDX_LOCAL_CACHE_DIR }}
           secrets: |
@@ -76,7 +81,7 @@ jobs:
         with:
           push: false
           load: true
-          target: local
+          target: ${{ inputs.docker_target }}
           tags: ${{ github.event.repository.name }}
           secrets: |
             CODEARTIFACT_TOKEN_DEV=${{ env.CODEARTIFACT_TOKEN_DEV }}

--- a/.github/workflows/swaggerhub.yml
+++ b/.github/workflows/swaggerhub.yml
@@ -25,6 +25,11 @@ on:
         type: string
         description: The URL of the ruleset to use for linting
         default: https://cdn.orfium.com/platform/prod/api-standardization/ruleset-latest.yml
+      docker_target:
+        required: false
+        type: string
+        description: This is the target of the build.
+        default: local
     secrets:
       SWAGGERHUB_TOKEN:
         required: true
@@ -78,7 +83,7 @@ jobs:
         with:
           push: false
           load: true
-          target: local
+          target: ${{ inputs.docker_target }}
           tags: ${{ github.event.repository.name }}
           cache-from: type=local,src=${{ inputs.BUILDX_LOCAL_CACHE_DIR }}
           secrets: |
@@ -91,7 +96,7 @@ jobs:
         with:
           push: false
           load: true
-          target: local
+          target: ${{ inputs.docker_target }}
           tags: ${{ github.event.repository.name }}
           secrets: |
             CODEARTIFACT_TOKEN_DEV=${{ env.CODEARTIFACT_TOKEN_DEV }}

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -53,6 +53,11 @@ on:
       AWS_CD_ROLE:
         required: false
         type: string
+      docker_target:
+        required: false
+        type: string
+        description: This is the target of the build.
+        default: local
     secrets:
       TESTMO_TOKEN:
         description: API token for Orfium's Testmo account
@@ -111,7 +116,7 @@ jobs:
         with:
           push: false
           load: true
-          target: local
+          target: ${{ inputs.docker_target }}
           tags: ${{ github.event.repository.name }}
           cache-from: type=local,src=${{ inputs.BUILDX_LOCAL_CACHE_DIR }}
           secrets: |
@@ -124,7 +129,7 @@ jobs:
         with:
           push: false
           load: true
-          target: local
+          target: ${{ inputs.docker_target }}
           tags: ${{ github.event.repository.name }}
           secrets: |
             CODEARTIFACT_TOKEN_DEV=${{ env.CODEARTIFACT_TOKEN_DEV }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,6 +26,11 @@ on:
       AWS_CD_ROLE:
         required: false
         type: string
+      docker_target:
+        required: false
+        type: string
+        description: This is the target of the build.
+        default: local
     secrets:
       PR_TOKEN:
         required: true
@@ -79,7 +84,7 @@ jobs:
         with:
           push: false
           load: true
-          target: local
+          target: ${{ inputs.docker_target }}
           tags: ${{ github.event.repository.name }}
           cache-from: type=local,src=${{ inputs.BUILDX_LOCAL_CACHE_DIR }}
           secrets: |
@@ -92,7 +97,7 @@ jobs:
         with:
           push: false
           load: true
-          target: local
+          target: ${{ inputs.docker_target }}
           tags: ${{ github.event.repository.name }}
           secrets: |
             CODEARTIFACT_TOKEN_DEV=${{ env.CODEARTIFACT_TOKEN_DEV }}


### PR DESCRIPTION
# Orfium GitHub Actions

## Description

As we currently do in other reusable workflows (e.g https://github.com/Orfium/orfium-github-actions/blob/8fbdccb4c8aeb4f7f571bb8e3a609f926bfcd42c/.github/workflows/build-local-images-v2.yml#L115 ) we can add the docker target as input of the reusable workflow instead of hardcoding it as local or something else. The reason behind this is that some teams may have different name of docker target layer.

## Checklist

<!-- Please check everything that applies: -->

- [x] I have reviewed my code and checked that there are no unrelated changes in this pull request
- [ ] I have created a JIRA ticket describing the purpose of this pull request
- [ ] I have checked if the changes to the templates are breaking or have contacted the DevOps team for feedback
- [ ] I have updated the template with the Actionlint Format guidelines: [Actionlint](https://github.com/rhysd/actionlint#readme). Information on how to do that are provided on the CONTRIBUTING.md file under docs/ folder.