### PR TITLE
fix(monorepo): keep one build with exclusion in map files for s3

### DIFF
--- a/.github/workflows/deploy-frontend-monorepo.yml
+++ b/.github/workflows/deploy-frontend-monorepo.yml
@@ -210,12 +210,9 @@ jobs:
           # We want to use literal backticks in "--query", not trying to expand to something else
           # shellcheck disable=SC2016
           DISTRIBUTION_ID=$(aws cloudformation describe-stacks --stack-name "$STACKNAME" --query 'Stacks[0].Outputs[?OutputKey==`FeCloudFrontDistributionId`].OutputValue' --output text)
-          aws s3 sync "$GITHUB_WORKSPACE/${{ inputs.app-directory-name }}/build/" "s3://${S3_BUCKET_NAME}/"
+          aws s3 sync "$GITHUB_WORKSPACE/${{ inputs.app-directory-name }}/build/" "s3://${S3_BUCKET_NAME}/" --exclude "*.js.map"
           INVALIDATION_ID=$(aws cloudfront create-invalidation --distribution-id "$DISTRIBUTION_ID" --paths "/*" | jq -r .Invalidation.Id)
           echo "INVALIDATION_ID is $INVALIDATION_ID"
-
-      - name: Generate sourcemaps
-        run: pnpm build:sentry --filter=./${{ inputs.app-directory-name }}
 
       - name: Set deployment env
         id: set-environment
@@ -232,7 +229,16 @@ jobs:
           fi
 
       - name: Set new release env
-        run: echo "latest_tag=$(git tag | sort --version-sort | tail -n1)" >> "$GITHUB_ENV"
+        run: | 
+          # get all versions of the deployment
+          NAME=$(jq -r '.name' package.json)
+          VERSION=$(jq -r '.version' package.json)
+          echo "PACKAGE_NAME=$NAME" >> "$GITHUB_ENV"
+          echo "PACKAGE_VERSION=$VERSION" >> "$GITHUB_ENV"
+
+          # set sentry release based on the versions
+          SENTRY_RELEASE="${PACKAGE_NAME}-${PACKAGE_VERSION}"
+          echo "SENTRY_RELEASE=$SENTRY_RELEASE" >> "$GITHUB_ENV"
 
       - name: Sentry release 📌
         if: ((github.ref == 'refs/heads/main' || github.ref == 'refs/heads/master' || github.ref == 'refs/heads/staging') && github.event_name == 'push')
@@ -245,7 +251,7 @@ jobs:
           environment: ${{ steps.set-environment.outputs.ENVIRONMENT_ID }}
           sourcemaps: ${{ inputs.app-directory-name }}/build
           ignore_missing: true
-          version: ${{ env.latest_tag }}
+          version: ${{ env.SENTRY_RELEASE }}
 
       - name: Update deployment status (success)
         if: success()


### PR DESCRIPTION
# Orfium GitHub Actions

## Description

This PR introduces a fix for building the frontend. Currently, we need to build processes, one to build without the sourcemaps to upload to AWS and a second one with sourcemaps for SENTRY. 

With this proposal there is going to be one build for all with the sourcemaps but the deployment will exclude them

changes are based on
https://docs.aws.amazon.com/cli/latest/reference/s3/#use-of-exclude-and-include-filters

#### Extras
introduce a better release tag for sentry with the app name and version e.g `earnings-0.0.1`

## Checklist

<!-- Please check everything that applies: -->

- [x] I have reviewed my code and checked that there are no unrelated changes in this pull request
- [ ] I have created a JIRA ticket describing the purpose of this pull request
- [x] I have checked if the changes to the templates are breaking or have contacted the DevOps team for feedback
- [x] I have updated the template with the Actionlint Format guidelines: [Actionlint](https://github.com/rhysd/actionlint#readme). Information on how to do that are provided on the CONTRIBUTING.md file under docs/ folder.