### PR TITLE
fix(monorepo): adjust node heap size for build

### DIFF
--- a/.github/workflows/deploy-frontend-monorepo.yml
+++ b/.github/workflows/deploy-frontend-monorepo.yml
@@ -139,6 +139,8 @@ jobs:
           pnpm config set always-auth true || echo "This fails for versions > 18.13"
 
       - name: Setup env, install dependencies, and build app
+        env:
+          NODE_OPTIONS: "--max-old-space-size=4096"
         run: |
           set -o allexport
           # Load optional common configuration


### PR DESCRIPTION
# Orfium GitHub Actions

## Description

This PR adjusts the node heap size to 4Gb for the build step only, since rights cloud needs more memory when generating the build with sourcemaps.

Related info: https://github.com/actions/runner-images/issues/70

## Checklist

<!-- Please check everything that applies: -->

- [x] I have reviewed my code and checked that there are no unrelated changes in this pull request
- [ ] I have created a JIRA ticket describing the purpose of this pull request
- [x] I have checked if the changes to the templates are breaking or have contacted the DevOps team for feedback
- [x] I have updated the template with the Actionlint Format guidelines: [Actionlint](https://github.com/rhysd/actionlint#readme). Information on how to do that are provided on the CONTRIBUTING.md file under docs/ folder.