### PR TITLE
feat: support aws registry on test, precommit and swaggerhub

### DIFF
--- a/.github/workflows/precommit.yml
+++ b/.github/workflows/precommit.yml
@@ -10,6 +10,19 @@ on:
       codeartifact_encrypted_token_prod:
         required: false
         type: string
+      ECR_LOGIN_FLAG:
+        required: false
+        type: boolean
+        default: false
+      ECR_REGISTRY:
+        required: false
+        type: string
+      ECR_REGION:
+        required: false
+        type: string
+      AWS_CD_ROLE:
+        required: false
+        type: string
       docker_target:
         required: false
         type: string
@@ -31,14 +44,14 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      
+
       - name: Set up Docker Buildx
         id: buildx
         uses: docker/setup-buildx-action@v3
         with:
           driver-opts: |
             image=moby/buildkit:master
-      
+
       - name: Set up Local Cache for Docker layers
         if: "${{ inputs.BUILDX_LOCAL_CACHE_DIR != '' }}"
         uses: actions/cache@v4
@@ -47,7 +60,7 @@ jobs:
           key: ${{ runner.os }}-buildx-local-${{ github.sha }}
           restore-keys: |
             ${{ runner.os }}-buildx-local-
-      
+
       - name: Decrypt Codeartifact dev token
         if: "${{ inputs.codeartifact_encrypted_token_dev != '' }}"
         run: |
@@ -62,6 +75,21 @@ jobs:
           echo "::add-mask::$token"
           echo "CODEARTIFACT_TOKEN_PROD=$token" >> "$GITHUB_ENV"
 
+      - name: Configure AWS credentials
+        id: test-aws-configure
+        if: ${{ inputs.ECR_LOGIN_FLAG }}
+        uses: aws-actions/configure-aws-credentials@v4.0.2
+        with:
+          role-to-assume: ${{ inputs.AWS_CD_ROLE }}
+          aws-region: ${{ inputs.ECR_REGION }}
+
+      - name: Login to ECR
+        id: test-ecr-login
+        if: ${{ inputs.ECR_LOGIN_FLAG }}
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ inputs.ECR_REGISTRY }}
+
       - name: Build local image from Cache
         if: "${{ inputs.BUILDX_LOCAL_CACHE_DIR != '' }}"
         uses: docker/build-push-action@v5
@@ -74,7 +102,7 @@ jobs:
           secrets: |
             CODEARTIFACT_TOKEN_DEV=${{ env.CODEARTIFACT_TOKEN_DEV }}
             CODEARTIFACT_TOKEN_PROD=${{ env.CODEARTIFACT_TOKEN_PROD }}
-      
+
       - name: Build local image
         if: "${{ inputs.BUILDX_LOCAL_CACHE_DIR == '' }}"
         uses: docker/build-push-action@v5
@@ -86,9 +114,9 @@ jobs:
           secrets: |
             CODEARTIFACT_TOKEN_DEV=${{ env.CODEARTIFACT_TOKEN_DEV }}
             CODEARTIFACT_TOKEN_PROD=${{ env.CODEARTIFACT_TOKEN_PROD }}
-      
+
       - name: Run pre commit
         run: make pre-commit args="--all-files"
-      
+
       - name: Tear down the Stack
         run: make down-volumes

--- a/.github/workflows/swaggerhub.yml
+++ b/.github/workflows/swaggerhub.yml
@@ -10,6 +10,19 @@ on:
       codeartifact_encrypted_token_prod:
         required: false
         type: string
+      ECR_LOGIN_FLAG:
+        required: false
+        type: boolean
+        default: false
+      ECR_REGISTRY:
+        required: false
+        type: string
+      ECR_REGION:
+        required: false
+        type: string
+      AWS_CD_ROLE:
+        required: false
+        type: string
       is_private:
         required: false
         type: string
@@ -46,14 +59,14 @@ jobs:
     steps:
       - name: Checkout Code Repository
         uses: actions/checkout@v4
-      
+
       - name: Set up Docker Buildx
         id: buildx
         uses: docker/setup-buildx-action@v3
         with:
           driver-opts: |
             image=moby/buildkit:master
-      
+
       - name: Set up Local Cache for Docker layers
         if: "${{ inputs.BUILDX_LOCAL_CACHE_DIR != '' }}"
         uses: actions/cache@v4
@@ -62,7 +75,7 @@ jobs:
           key: ${{ runner.os }}-buildx-local-${{ github.sha }}
           restore-keys: |
             ${{ runner.os }}-buildx-local-
-      
+
       - name: Decrypt Codeartifact dev token
         if: "${{ inputs.codeartifact_encrypted_token_dev != '' }}"
         run: |
@@ -77,6 +90,21 @@ jobs:
           echo "::add-mask::$token"
           echo "CODEARTIFACT_TOKEN_PROD=$token" >> "$GITHUB_ENV"
 
+      - name: Configure AWS credentials
+        id: test-aws-configure
+        if: ${{ inputs.ECR_LOGIN_FLAG }}
+        uses: aws-actions/configure-aws-credentials@v4.0.2
+        with:
+          role-to-assume: ${{ inputs.AWS_CD_ROLE }}
+          aws-region: ${{ inputs.ECR_REGION }}
+
+      - name: Login to ECR
+        id: test-ecr-login
+        if: ${{ inputs.ECR_LOGIN_FLAG }}
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ inputs.ECR_REGISTRY }}
+
       - name: Build local image from Cache
         if: "${{ inputs.BUILDX_LOCAL_CACHE_DIR != '' }}"
         uses: docker/build-push-action@v5
@@ -89,7 +117,7 @@ jobs:
           secrets: |
             CODEARTIFACT_TOKEN_DEV=${{ env.CODEARTIFACT_TOKEN_DEV }}
             CODEARTIFACT_TOKEN_PROD=${{ env.CODEARTIFACT_TOKEN_PROD }}
-      
+
       - name: Build local image
         if: "${{ inputs.BUILDX_LOCAL_CACHE_DIR == '' }}"
         uses: docker/build-push-action@v5
@@ -104,7 +132,7 @@ jobs:
 
       - name: Create Swaggerhub Definition
         run: make swaggerhub
-      
+
       - uses: stoplightio/spectral-action@v0.8.11
         if: "${{ inputs.lint }}"
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -63,7 +63,7 @@ jobs:
           key: ${{ runner.os }}-buildx-local-${{ github.sha }}
           restore-keys: |
             ${{ runner.os }}-buildx-local-
-      
+
       - name: Decrypt Codeartifact dev token
         if: "${{ inputs.codeartifact_encrypted_token_dev != '' }}"
         run: |
@@ -77,31 +77,6 @@ jobs:
           token=$(gpg --decrypt --quiet --batch --passphrase "${{ secrets.GPG_CODEARTIFACT_TOKEN_PASSPHRASE }}" --output - <(echo "${{ inputs.codeartifact_encrypted_token_prod }}" | base64 --decode))
           echo "::add-mask::$token"
           echo "CODEARTIFACT_TOKEN_PROD=$token" >> "$GITHUB_ENV"
-
-      - name: Build local image from Cache
-        if: "${{ inputs.BUILDX_LOCAL_CACHE_DIR != '' }}"
-        uses: docker/build-push-action@v5
-        with:
-          push: false
-          load: true
-          target: ${{ inputs.docker_target }}
-          tags: ${{ github.event.repository.name }}
-          cache-from: type=local,src=${{ inputs.BUILDX_LOCAL_CACHE_DIR }}
-          secrets: |
-            CODEARTIFACT_TOKEN_DEV=${{ env.CODEARTIFACT_TOKEN_DEV }}
-            CODEARTIFACT_TOKEN_PROD=${{ env.CODEARTIFACT_TOKEN_PROD }}
-      
-      - name: Build local image
-        if: "${{ inputs.BUILDX_LOCAL_CACHE_DIR == '' }}"
-        uses: docker/build-push-action@v5
-        with:
-          push: false
-          load: true
-          target: ${{ inputs.docker_target }}
-          tags: ${{ github.event.repository.name }}
-          secrets: |
-            CODEARTIFACT_TOKEN_DEV=${{ env.CODEARTIFACT_TOKEN_DEV }}
-            CODEARTIFACT_TOKEN_PROD=${{ env.CODEARTIFACT_TOKEN_PROD }}
 
       - name: Configure AWS credentials
         id: test-aws-configure
@@ -118,24 +93,49 @@ jobs:
         with:
           registry: ${{ inputs.ECR_REGISTRY }}
 
+      - name: Build local image from Cache
+        if: "${{ inputs.BUILDX_LOCAL_CACHE_DIR != '' }}"
+        uses: docker/build-push-action@v5
+        with:
+          push: false
+          load: true
+          target: ${{ inputs.docker_target }}
+          tags: ${{ github.event.repository.name }}
+          cache-from: type=local,src=${{ inputs.BUILDX_LOCAL_CACHE_DIR }}
+          secrets: |
+            CODEARTIFACT_TOKEN_DEV=${{ env.CODEARTIFACT_TOKEN_DEV }}
+            CODEARTIFACT_TOKEN_PROD=${{ env.CODEARTIFACT_TOKEN_PROD }}
+
+      - name: Build local image
+        if: "${{ inputs.BUILDX_LOCAL_CACHE_DIR == '' }}"
+        uses: docker/build-push-action@v5
+        with:
+          push: false
+          load: true
+          target: ${{ inputs.docker_target }}
+          tags: ${{ github.event.repository.name }}
+          secrets: |
+            CODEARTIFACT_TOKEN_DEV=${{ env.CODEARTIFACT_TOKEN_DEV }}
+            CODEARTIFACT_TOKEN_PROD=${{ env.CODEARTIFACT_TOKEN_PROD }}
+
       - name: Run tests
         run: make test
-      
+
       - name: Tear down the Stack
         run: make down-volumes
-      
+
       - name: Create Coverage Cache Registry
         id: coverage-cache
         uses: actions/cache@v4
         with:
           path: ${{ inputs.COVERAGE_CACHE_DIR }}
           key: ${{ runner.os }}-coverage-reports-${{ github.sha }}
-      
+
       - name: Cache Coverage
         run: |
           mkdir -p ${{ inputs.COVERAGE_CACHE_DIR }}-new
           mv coverage.xml ${{ inputs.COVERAGE_CACHE_DIR }}-new/coverage.xml
-      
+
       - name: Refresh Coverage cache
         run: |
           rm -rf ${{ inputs.COVERAGE_CACHE_DIR }}
@@ -143,4 +143,3 @@ jobs:
         # Temp fix
         # https://github.com/docker/build-push-action/issues/252
         # https://github.com/moby/buildkit/issues/1896
-      


### PR DESCRIPTION
# Orfium GitHub Actions

## Description

<!-- Write and explain of the changes introduced by this PR for the reviewers to fully understand or link the related JIRA ticket-->

During the development of https://github.com/Orfium/sm-neo-audio-tools-api we found the need to retrieve an image our ECR registry. We need to be able to provide a registry during those steps. This is required in order to be able to use such layers.

For test we already had that but the login was provided after the image building step. This was OK for asset-service but it cannot handle the case of sm-neo-audio-tools.

We are also adding this capabitilty in swaggerhub and precommit workflows. The changes are backwards compatible.

## Checklist

<!-- Please check everything that applies: -->

- [ ] I have reviewed my code and checked that there are no unrelated changes in this pull request
- [ ] I have created a JIRA ticket describing the purpose of this pull request
- [ ] I have checked if the changes to the templates are breaking or have contacted the DevOps team for feedback
- [ ] I have updated the template with the Actionlint Format guidelines: [Actionlint](https://github.com/rhysd/actionlint#readme). Information on how to do that are provided on the CONTRIBUTING.md file under docs/ folder.