### PR TITLE
fix: release of the sentry in monorepo

### DIFF
--- a/.github/workflows/deploy-frontend-monorepo.yml
+++ b/.github/workflows/deploy-frontend-monorepo.yml
@@ -229,17 +229,15 @@ jobs:
             echo "This is a staging environment"
             echo "ENVIRONMENT_ID=staging" >> "$GITHUB_OUTPUT"
           fi
+      
+      - name: Set Sentry release version
+        run: |
+          # Change directory to the specified app directory
+          cd ${{ inputs.app-directory-name }}
 
-      - name: Set new release env
-        run: | 
-          # get all versions of the deployment
-          NAME=$(jq -r '.name' ${{ inputs.app-directory-name }}/package.json)
-          VERSION=$(jq -r '.version' ${{ inputs.app-directory-name }}/package.json)
-          echo "PACKAGE_NAME=$NAME" >> "$GITHUB_ENV"
-          echo "PACKAGE_VERSION=$VERSION" >> "$GITHUB_ENV"
+          # Extract the version from the `release-it`. This will export either current or future release in order not to coupled this with release workflow
+          SENTRY_RELEASE=$(pnpm release --ci --dry-run | grep -oE "([0-9]+\.[0-9]+\.[0-9]+|[0-9]+\.[0-9]+\.[0-9]+)$" | tail -n1)
 
-          # set sentry release based on the versions
-          SENTRY_RELEASE="${PACKAGE_NAME}-${PACKAGE_VERSION}"
           echo "SENTRY_RELEASE=$SENTRY_RELEASE" >> "$GITHUB_ENV"
 
       - name: Sentry release 📌


### PR DESCRIPTION
# Orfium GitHub Actions

## Description

This once more solves the issues we are facing with sentry. We solved in the past how we can upload the current version but it did;t worked when a new release was going to be made as the release workflow is separated from the main CI workflow. 

With this solution we dry-run the release step so we can calculate the version to upload to sentry.

## Checklist

<!-- Please check everything that applies: -->

- [x] I have reviewed my code and checked that there are no unrelated changes in this pull request
- [x] I have created a JIRA ticket describing the purpose of this pull request
- [x] I have checked if the changes to the templates are breaking or have contacted the DevOps team for feedback
- [ ] I have updated the template with the Actionlint Format guidelines: [Actionlint](https://github.com/rhysd/actionlint#readme). Information on how to do that are provided on the CONTRIBUTING.md file under docs/ folder.