### PR TITLE
feat: remove swaggerhub lint temporarily until gobinaries.com is up

### DIFF
--- a/.github/workflows/swaggerhub.yml
+++ b/.github/workflows/swaggerhub.yml
@@ -133,11 +133,11 @@ jobs:
       - name: Create Swaggerhub Definition
         run: make swaggerhub
 
-      - uses: stoplightio/spectral-action@v0.8.11
-        if: "${{ inputs.lint }}"
-        with:
-          file_glob: 'test.yaml'
-          spectral_ruleset: ${{ inputs.linter_ruleset }}
+      # - uses: stoplightio/spectral-action@v0.8.11
+      #   if: "${{ inputs.lint }}"
+      #   with:
+      #     file_glob: 'test.yaml'
+      #     spectral_ruleset: ${{ inputs.linter_ruleset }}
 
       - name: Post to Swaggerhub
         if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/master'


### PR DESCRIPTION
# Orfium GitHub Actions

## Description

<!-- Write and explain of the changes introduced by this PR for the reviewers to fully understand or link the related JIRA ticket-->
This pull request includes a minor change to the `.github/workflows/swaggerhub.yml` file. The change comments out the step that uses the `stoplightio/spectral-action` for linting Swagger files, effectively disabling it for now.

* Workflow adjustments:
  * [`.github/workflows/swaggerhub.yml`](diffhunk://#diff-63b71f9e79bf09b89658151c5c49e71fa32b20ce098deefd394f85b39d0ed385L136-R140): Commented out the `stoplightio/spectral-action` step, which previously performed Swagger file linting based on the provided ruleset.
## Checklist

<!-- Please check everything that applies: -->

- [ ] I have reviewed my code and checked that there are no unrelated changes in this pull request
- [ ] I have created a JIRA ticket describing the purpose of this pull request
- [ ] I have checked if the changes to the templates are breaking or have contacted the DevOps team for feedback
- [ ] I have updated the template with the Actionlint Format guidelines: [Actionlint](https://github.com/rhysd/actionlint#readme). Information on how to do that are provided on the CONTRIBUTING.md file under docs/ folder.